### PR TITLE
Make the site work with HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "js-hqx"]
 	path = js-hqx
-	url = https://github.com/nickdarnell/js-hqx
+	url = https://github.com/phoboslab/js-hqx

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1" />
     <meta name="description" content="Depixelizer : Upscale your sprites with awesome! (and hqNx)" />
 
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 	<script type="text/javascript" src="javascripts/jquery-ui-1.10.3.custom.min.js"></script>
 	
 	<link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">


### PR DESCRIPTION
The depixelizer page doesn't presently work with HTTPS because jQuery is loaded from a HTTP-based location ("mixed content"). Users that use plugins such as "HTTPS Everywhere", which will automatically redirect to HTTPS versions of github.io pages, thus require an exception in order to use the depixelizer. This PR fixes the reference to use a protocol-relative URL.

Additionally, the .gitmodules is updated to point to the phoboslab js-hqx repo, since the nickdarnell one does not seem to exist; this was blocking Github from being able to deploy it via the gh-pages mechanism.